### PR TITLE
Should test compare values of resulting list, or list references?

### DIFF
--- a/test.js
+++ b/test.js
@@ -6,9 +6,9 @@ const array2 = ['C', false, 'R', false,'O', false, 'D', false, 'E', false, 'P', 
 
 
 it('should return correct array', () => {
-    assert.equal(getPositiveKeysOfBoolset(array1), ['C', 'O', 'D', 'E']);
+    assert.deepEqual(getPositiveKeysOfBoolset(array1), ['C', 'O', 'D', 'E']);
 });
 
 it('should return empty set if there is no positive value in boolset', () => {
-    assert.equal(getPositiveKeysOfBoolset(array2), []);
+    assert.deepEqual(getPositiveKeysOfBoolset(array2), []);
 });


### PR DESCRIPTION
Current test checks for result reference(shallow equality check), so it is required to modify original list to pass the test.